### PR TITLE
use CRAN version of shinytest and learnr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,4 @@ Imports: bookdown,
 Suggests:
   shinytest,
   testthat
-Remotes:
-    rstudio/shinytest,
-    rstudio/learnr
 RoxygenNote: 6.1.0


### PR DESCRIPTION
had failiing tests on master - removed remotes for shinytest and learnr, but in fact macOS passed on master and linux passed on second try. 

nevertheless, this branch only uses CRAN versions, so probably safer. will merge.